### PR TITLE
Updates for CLI v1.0.0

### DIFF
--- a/dev_cli.md
+++ b/dev_cli.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2017
-lastupdated: "2017-06-13"
+lastupdated: "2017-08-31"
 
 ---
 {:new_window: target="_blank"}  
@@ -14,16 +14,18 @@ lastupdated: "2017-06-13"
 # {{site.data.keyword.dev_cli_short}}
 {: #developercli}	
 
-The {{site.data.keyword.dev_cli_long}} provides an extensible command driven approach for creating, developing, and deploying a web project with the `dev` plug-in. Ideal for developers that would like to use command line control to develop end-to-end microservice applications.
+The {{site.data.keyword.dev_cli_long}} (formerly referred to as the Bluemix CLI Developer Plug-in) provides an extensible command driven approach for creating, developing, and deploying a web project, ideal for developers that would like to use command line control to develop end-to-end microservice applications.  
+
+Projects created or enabled for use with the tool come with pre-configured settings encapsulated in the `cli-config.yml` file. The `cli-config.yml` contains default entries used by the commands of the tool, that can be overridden by values passed via the command line.
 
 {: shortdesc}
 
-The {{site.data.keyword.dev_cli_notm}} uses two containers to facilitate building and testing your application. The first is the tools container, which contains the necessary utilities to build and test your application. The Dockerfile for this container is defined by the [`dockerfile-tools`](#command-parameters) parameter. You might think of it as a development container as it contains the tools normally useful for development of a particular runtime.
+The {{site.data.keyword.dev_cli_long}} uses two containers to facilitate building and testing your application. The first is the tools container, which contains the necessary utilities to build and test your application. The Dockerfile for this container is defined by the [`dockerfile-tools`](#command-parameters) parameter. You might think of it as a development container as it contains the tools normally useful for development of a particular runtime.
 
 The second container is the run container. This container is of a form suitable to be deployed for use, for example, in {{site.data.keyword.Bluemix}}. As a result, an entry point is defined that starts your application. When you select to run your application through the {{site.data.keyword.dev_cli_short}}, it uses this container. The Dockerfile for this container is defined by the [`dockerfile-run`](#run-parameters) parameter.
 
 
-## Adding the {{site.data.keyword.dev_cli_notm}}
+## Setting up the {{site.data.keyword.dev_cli_notm}}
 {: #add-cli}
 
 
@@ -34,17 +36,33 @@ You must obtain a few prerequisites to fully explore and properly utilize the {{
 
 <!--1. Install the [Cloud Foundry CLI ![External link icon](../icons/launch-glyph.svg "External link icon")](https://github.com/cloudfoundry/cli#getting-started).-->
 
-1. Install the [{{site.data.keyword.Bluemix}} CLI ![External link icon](../icons/launch-glyph.svg "External link icon")](http://clis.ng.bluemix.net/ui/home.html).
+1. Obtain a [{{site.data.keyword.Bluemix_notm}}](https://www.bluemix.net) ID.
 
-2. Obtain a [{{site.data.keyword.Bluemix_notm}}](https://www.bluemix.net) ID.
-
-3. If you plan on running and debugging applications locally, then you must also install [Docker ![External link icon](../icons/launch-glyph.svg "External link icon")](https://www.docker.com/get-docker).
+4. If you are using Microsoft Windows&trade;, you must use Windows 10 or later.
 
 
 ### Before you begin
-{: #before-install}
 
-1. Connect to an API endpoint in your [{{site.data.keyword.Bluemix_notm}} region](/docs/overview/whatisbluemix.html#ov_intro_reg). For example, enter the following command to connect to the {{site.data.keyword.Bluemix_notm}} US South region:
+#### Installing
+{: #installation}
+
+To install the tool, you can run the relevant command to invoke our installer. This will install dependencies as well, such as the Bluemix CLI, Kubernetes, Helm, and Docker. To install these, use these installation steps:
+
+**Mac and Linux:**  `curl -sL https://ibm.biz/idt-installer | bash`
+
+**Windows 10:**  `Set-ExecutionPolicy Unrestricted; iex(New-Object Net.WebClient).DownloadString('http://ibm.biz/idt-win-installer')`
+
+The [Appendix](#appendix) has the manual installation instructions for each component if you have need of them.
+
+Validate successful plug-in installation by running the following command:  
+
+	bx dev
+	{: codeblock}
+
+#### Configure Your Environment
+{: #configure-environment}
+
+1. Connect to an API endpoint in your [{{site.data.keyword.Bluemix_notm}} region](/docs/overview/cf.html#ov_intro_reg). For example, enter the following command to connect to the {{site.data.keyword.Bluemix_notm}} US South region:
 
 	```
 	bx api https://api.ng.bluemix.net
@@ -77,21 +95,10 @@ You must obtain a few prerequisites to fully explore and properly utilize the {{
 		```
 		{: codeblock}
 
+3. Set your ORG and SPACE using:
 
-### Installing
-{: #installation}
-
-1. Install the [{{site.data.keyword.dev_cli_short}} ![External link icon](../icons/launch-glyph.svg "External link icon")](/docs/cli/reference/bluemix_cli/index.html#install_plug-in){: new_window} by running the following command:
- 
 	```
-	bx plugin install dev -r Bluemix
-	```
-	{: codeblock}
-
-2. 	Validate successful plug-in installation by running the following command:  
- 
-	```
-	bx dev
+	bx target -o <value> -s <value>
 	```
 	{: codeblock}
 
@@ -104,12 +111,14 @@ Use the following commands to create a project, deploy, debug, and test it.
 ### Build
 {: #build}
 
-You can build your application by using the `build` command. The `build-cmd-run` configuration element is used to build the application. The `test`, `debug`, and `run` commands expect to find a compiled project so you must first run a build operation at least once beforehand.
+You can build your application by using the `build` command. The `test`, `debug`, and `run` commands expect to find a compiled project so you must first run a `build` operation beforehand.  
+
+The `build-cmd-debug` configuration element is used to build the application for all use except for `run`. You build your application for debugging by specifying the command line option `--debug`.  The `build-cmd-run` configuration element is used when building the application for use with the `run` command.
 
 Run the following command in your current project directory to build your application:  
 
 ```
-bx dev build
+bx dev build [--debug]
 ```
 {: codeblock}
 
@@ -120,12 +129,27 @@ bx dev build
 ### Code
 {: #code}
 
-Use the `code` command to download application code after deployment, so you can review it locally or make changes.
+Use the `code` command to download a previously created project with application template code and configuration files for the {{site.data.keyword.Bluemix_notm}}.  This is useful when you need to extract a second copy of a project you have created.
 
 Run the following command to download the code from a specified project.
 
 ```
 bx dev code <projectName>
+```
+{: codeblock}
+
+
+### Console
+{: #console}
+
+Use the `console` command to open a web browser to your application's web console on Bluemix.  You can run the `bx dev console` command from inside your project's folder, and the CLI attempts to find a matching project on Bluemix that has the same name as the current directory. If the system is not able to find a matching name, it opens the Web and Mobile dashboard on Bluemix instead of the specific project.
+
+Optionally, you can provide a project name and the CLI will skip matching based on folder/application name.  In this case, the CLI opens the named project's console in a web browser.  
+
+Run the following command to open a web browser to your application's web console.
+
+```
+bx dev console [projectName]
 ```
 {: codeblock}
 
@@ -146,61 +170,55 @@ bx dev create
 ### Debug
 {: #debug}
 
-You can debug your application through the `debug` command. A build must first be completed against the project by using the build command. When you invoke the `debug` command, a container is started which provides a debug port or ports as defined by the `container-port-map-debug` value. Connect your favorite debug tool to the port or ports, and you can debug your application as normal.
-
-**Limitation**: Swift projects are not available for debug.
+You can debug your application through the `debug` command. A build must first be completed against the project by using the build command with the `--debug` argument. When you invoke the `debug` command, a container is started which provides a debug port or ports as defined by the `container-port-map-debug` value in the cli-config.yml or specified on the command line. Connect your favorite debug tool to the port or ports, and you can debug your application as normal.
 
 First, compile your project:
 
 ```
-bx dev build
+bx dev build --debug
 ```
 {: codeblock}
 
 Run the following command in your current project directory to debug your application:
 
 ```
-bx dev debug
+bx dev debug 
 ```
 {: codeblock}	
 
 To exit the debug session use `CTRL-C`.
 
 
-#### Debug command parameters
+## Debug command parameters
 {: #debug-parameters}
 
 The following parameters are exclusive to the `debug` command and
-assist with debugging an application.
+assist with debugging an application. There are [additional parameters](#command-parameters) shared with other commands.
 
-##### `container-port-map-debug`
+### `container-port-map-debug`
 {: #port-map-debug}
 
 * Port mappings for the debug port. The first value is the port to use in the host OS, the second is the port in the container [host-port:container-port].
-* Usage: `bx dev debug --container-port-map-debug [7777:7777]`
+* Usage: `bx dev debug --container-port-map-debug 7777:7777`
 
-##### `build-cmd-debug`
+### `build-cmd-debug`
 {: #build-cmd-debug}
 
 * Parameter that is used to build code for DEBUG.
 * Usage: `bx dev debug --build-cmd-debug build.command.sh`
 
-##### `debug-cmd`
+### `debug-cmd`
 {: #debug-cmd}
 
 * Parameter that is used to specify a command to invoke debug in the tools container. Use this parameter if the `build-cmd-debug` starts your application in debug.
 * Usage: `bx dev debug --debug-cmd /the/debug/command`
 
-#### Local application debugging:
-{: #local-app-dev}
-
-For more information about local application debugging, see [Local application debugging](docs/cloudnative/dev_cli_local_debug.html#local-debug).
 
 
 ### Delete
 {: #delete}
 
-Use the `delete` command to remove projects from your {{site.data.keyword.Bluemix}} space. You can run the command without parameters to list available projects to delete. Project code and directories are not removed from your local disk space.
+Use the `delete` command to remove projects from your {{site.data.keyword.Bluemix}} space. You can run the command without parameters to list available projects and select the project from the numbered list to delete. Project code and directories are not removed from your local disk space.
 
 Run the following command to delete your project from {{site.data.keyword.Bluemix}}:
 
@@ -216,7 +234,23 @@ bx dev delete <projectName>
 ### Deploy
 {: #deploy}
 
-You can push an application to {{site.data.keyword.Bluemix}} through the `deploy` command when a `manifest.yml` file is present in your project's root directory.
+You can deploy an application as a Cloud Foundry application or as a container.
+
+To deploy as a Cloud Foundry application to {{site.data.keyword.Bluemix}}, a `manifest.yml` file must be present in your project's root directory.
+
+To deploy an application as a container, you must locally install [Kubernetes](https://kubernetes.io/) and [Helm](https://github.com/kubernetes/helm). You can use the the [installation instructions](#installation) at the top of this page as your guide.
+
+You must also define the location to a Helm chart with the `chart-path` configuration element and have configured the `deploy-target` element to `container`, and the `deploy-image-target` element in the cli-config.yml.  To deploy to {{site.data.keyword.Bluemix}} specifically, set the configuration element `ibm-cluster` to the name of the Kubernetes cluster you have created in {{site.data.keyword.Bluemix}} as described [here](https://console.bluemix.net/docs/containers/cs_tutorials.html#cs_tutorials).
+
+```
+    chart-path: "chart/myapplication"
+
+    deploy-target: "container"
+
+    deploy-image-target: "registry.<Bluemix Region>.bluemix.net/<Container Registry Namespace>/<App-Name>"
+
+    ibm-cluster: "mycluster"
+    ```
 
 Run the following command in your current project directory to build your application:  
 
@@ -225,12 +259,94 @@ bx dev build
 ```
 {: codeblock}
 
-Run the following command to deploy your project to {{site.data.keyword.Bluemix}}:
+Run the following command in your current project directory to deploy your project:
 
 ```
 bx dev deploy
 ```
 {: codeblock}
+
+
+## Parameters for deploy
+{: #deploy-parameters}
+
+The following parameters can be used with the `deploy` command or by updating the project's `cli-config.yml` file directly. There are [additional parameters](#command-parameters) shared with other commands.
+
+### `chart-path`
+{: #chart-path}
+
+* Parameter used for a container deployment to specify the location of the Helm chart used for the deployment.
+* Usage `bx dev deploy --chart-path [/the/path]`
+
+### `deploy-target`
+{: #deploy-target}
+
+* Parameter optionally used to indicate the type of deployment to be completed.  The default deployment type is buildpack.
+* Usage `bx dev deploy -t|--target buildpack|container`
+
+### `deploy-image-target`
+{: #deploy-image-target}
+
+* Parameter used with a container deployment as the target image name for the deployment (e.g. to tag to a Docker registry).  The value must not include a version for example:  image-name:{version} as the version is automatically incremented and appended by `deploy`.
+* Usage `bx dev deploy --deploy-image-target [image-name]`
+
+### `ibm-cluster`
+{: #ibm-cluster}
+
+* Parameter optionally used to define the name of the Kubernetes cluster for a container deployment to {{site.data.keyword.Bluemix}}
+* Usage `bx dev deploy --ibm-cluster [cluster-name]`
+
+
+### Enable
+{: #enable}
+
+Enable an existing project for {{site.data.keyword.Bluemix_notm}} deployment. The `enable` command attempts to automatically detect the language of an existing project and then prompt for necessary additional information. This generates and adds files that can be used for local Docker containers, CloudFoundry deployment, or Kubernetes/Container Deployment. 
+
+Run the following command to enable an existing project in the current directory for {{site.data.keyword.Bluemix_notm}} deployment:
+
+```
+bx dev enable
+```
+{: codeblock}
+
+The presence of necessary files provides project language detection for a valid project structure.  
+
+* The presence of a `package.json` file identifies a Node.js project.
+* The presence of a `package.swift` file identifies a Swift project.
+* The presence of either a `setup.py` or `requirements.txt` file identifies a Python project.
+* The presence of either a `pom.xml` or `build.gradle` file identifies a Java project.
+	* The presence of a `pom.xml` identifies a Maven project.
+	* The presence of a `build.gradle` identifies a Gradle project.
+
+Optionally, you can also override the detected project language using the `--language` argument.  However, only valid and complete projects are supported. The enable command does not modify your source code. 
+
+Language options include:
+* node
+* swift
+* python
+* java-ee (interpreted as Java - Java EE)
+* java-mp (interpreted as Java - Java MicroProfile)
+* java-spring (interpreted as Java - Spring Framework)
+
+Files created using the `bx dev enable` command that have naming conflicts with existing files in the project folder are saved with a `.merge` file extension.  
+
+## Parameters for enable
+{: #enable-parameters}
+
+The following parameters can be used with the `enable` command or by updating the project's `cli-config.yml` file directly. There are [additional parameters](#command-parameters) shared with other commands.
+
+### `language`
+{: #enable-language}
+
+* Parameter used to specify the language of the project to be enabled.
+* Usage `bx dev enable -l|--language [language]`
+
+### `force`
+{: #enable-force}
+
+* Parameter used to force re-enabling an already enabled project.
+* Usage `bx dev enable -f|--force`
+
 
 
 ### Help
@@ -275,7 +391,7 @@ bx dev edit
 ### Run
 {: #run}
 
-You can run your application through the `run` command. A build must first be completed against the project by using the `build` command. When you invoke the run command, the run container is started and exposes the ports as defined by the `container-port-map` parameter. The `run-cmd` parameter can be used to invoke the application if the run container Dockerfile does not contain an entry point to complete this step. 
+You can run your application through the `run` command. A build must first be completed against the project by using the `build` command. When you invoke the `run` command, the run container is started and exposes the ports as defined by the `container-port-map` parameter. The `run-cmd` parameter can be used to invoke the application if the run container Dockerfile does not contain an entry point to complete this step. 
 
 First, compile your project:
 
@@ -294,43 +410,44 @@ bx dev run
 To exit the session use `CTRL-C`.
 
 
-#### Run Parameters
+## Run Parameters
 {: #run-parameters}
 
 The following parameters are exclusive to the `run` command and
-assist with managing your application within the run container.
+assist with managing your application within the run container. 
+There are [additional parameters](#command-parameters) shared with other commands.
 
-##### `container-name-run`
+### `container-name-run`
 {: #container-name-run}
 	
 * Container name for the run container.
 * Usage: `bx dev run --container-name-run [<projectName>]`
 
-##### `container-path-run`
+### `container-path-run`
 {: #container-path-run}
 
 * Location in the container to share on run.
 * Usage: `bx dev run --container-path-run [/path/to/app]`
 
-##### `host-path-run`
+### `host-path-run`
 {: #host-path-run}
 
 * Location on the host system to share in the container on run.
 * Usage: `bx dev run --host-path-run [/path/to/app/bin]`
 
-##### `dockerfile-run`
+### `dockerfile-run`
 {: #dockerfile-run}
 
 * Dockerfile for the run container.
-* Usage: `bx dev run --dockerfile-run [/path/to/Dockerfile.yml]`
+* Usage: `bx dev run --dockerfile-run [/path/to/Dockerfile]`
 
-##### `image-name-run`
+### `image-name-run`
 {: #image-name-run}
 
 * Image to create from `dockerfile-run`.
 * Usage: `bx dev run --image-name-run [/path/to/image-name]`
 
-##### `run-cmd`
+### `run-cmd`
 {: #run-cmd}
 
 * Parameter that is used to run code in the run container. Use this parameter if your image starts your application.
@@ -364,18 +481,36 @@ bx dev stop
 ```
 {: codeblock}
 
-To stop a container that is not defined in the `cli-config.yml` file, you can specify an extra command line parameter to override it. For the tools container, use the [`--container-name-tools`](#container-name-tools) parameter, and for the run container use the [`--container-name-run`](#container-name-run) parameter. If no containers are specified in the `cli-config.yml` file or on the command line, the stop command simply returns.
+To stop a container that is not defined in the `cli-config.yml` file, you can specify an extra command line parameter to override it.  If no containers are specified in the `cli-config.yml` file or on the command line, the stop command simply returns.
+
+## Stop Parameters
+{: #stop-parameters}
+
+The following parameters are used for the `stop` command. There are [additional parameters](#command-parameters) shared with other commands.
+
+### `container-name-run`
+{: #container-name-run}
+	
+* Container name for the run container.
+* Usage: `bx dev stop --container-name-run [<projectName>]`
+
+### `container-name-tools`
+{: #container-name-tools}
+	
+* Container name for the tools container.
+* Usage: `bx dev stop --container-name-tools [<projectName>]`
+
 
 
 ### Test
 {: #test}
 
-You can test your application through the `test` command. A build must first be completed against the project by using the `build` command. The tools container is then used to invoke the `test-cmd` for the application.
+You can test your application through the `test` command. A build must first be completed against the project by using the `build --debug` command. The tools container is then used to invoke the `test-cmd` for the application.
 
 First, compile your project:
 
 ```
-bx dev build
+bx dev build --debug
 ```
 {: codeblock}
 
@@ -387,8 +522,16 @@ bx dev test
 {: codeblock}
 
 
-[Test command parameters](#command-parameters)
+[Test command parameters]
+{: #test-parameters}
 
+The following parameter is exclusive to the `test` command.  There are [additional parameters](#command-parameters) shared with other commands.
+
+### `test-cmd`
+{: #test-cmd}
+
+* Parameter that is used to specify a command to test code in the tools container.
+* Usage: `bx dev test --test-cmd /the/test/command`
 
 ## Parameters for build, debug, run, and test
 {: #command-parameters}
@@ -397,11 +540,23 @@ The following parameters can be used with the `build|debug|run|test` commands or
 
 **Note**: Command parameters that are entered on the command line take precedence over the `cli-config.yml` configuration.
 
+### `config-file`  
+{: #config-file}
+
+* Specify a cli-config.yml file to use for a command.
+* Usage: `bx dev <build|debug|run|status|stop|test> --config-file cli-config.yml`
+
+### `container-name-run`  
+{: #container-name-run}
+
+* Container name for the run container.
+* Usage: `bx dev <run|status|stop> --container-name-run [<projectName>]`
+
 ### `container-name-tools`  
 {: #container-name-tools}
 
 * Container name for the tools container.
-* Usage: `bx dev <build|debug|run|stop|test> --container-name-tools [<projectName>]`
+* Usage: `bx dev <build|debug|run|status|stop|test> --container-name-tools [<projectName>]`
 
 ### `host-path-tools`
 {: #host-path-tools}
@@ -433,17 +588,25 @@ The following parameters can be used with the `build|debug|run|test` commands or
 * Image to create from `dockerfile-tools`.
 * Usage: `bx dev <build|debug|run|test> --image-name-tools [path/to/image-name]`
 
+### `container-mounts-run`
+{: #container-mounts-run}
+
+* Use this option to define mounts between the host system and the run container.
+* As a best practice and to prevent unexpected results, you should build and run using the same mount settings.
+* Usage: `bx dev <build|run|test> --container-mounts-run [/relative/path/to/host/dir:/absolute/path/to/container/dir, etc.]`
+
+### `container-mounts-tools`
+{: #container-mounts-tools}
+
+* Use this option to define mounts between the host system and the tools container.
+* As a best practice and to prevent unexpected results, you should build and debug using the same mount settings.
+* Usage: `bx dev <build|debug|test> --container-mounts-tools [/relative/path/to/host/dir:/absolute/path/to/container/dir, etc.]`
+
 ### `build-cmd-run`
 {: #build-cmd-run}
 
 * Parameter that is used to specify a command to build code for all use but DEBUG.
 * Usage: `bx dev <build|debug|run|test> --build-cmd-run [some.build.command]`
-
-### `test-cmd`
-{: #test-cmd}
-
-* Parameter that is used to specify a command to test code in the tools container.
-* Usage: `bx dev <build|debug|run|test> --test-cmd [/the/test/command]`
 
 ### `trace`
 {: #trace}
@@ -452,3 +615,20 @@ The following parameters can be used with the `build|debug|run|test` commands or
 * Usage: `bx dev <build|debug|run|test> --trace`
 
 
+## APPENDIX
+{: #appendix}
+
+All prerequisites will install for most users using the platform installers at the top of this page. If you need to manually install any components, here are the instructions:
+
+For running and debugging applications locally, you must also install [Docker ![External link icon](../icons/launch-glyph.svg "External link icon")](https://www.docker.com/get-docker).
+
+For deploying an application as a container, you must also install install Kubernetes:
+* Mac users: `curl --progress-bar -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl`
+
+* Linux users: `curl --progress-bar -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl`
+
+* Windows users: `curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/windows/amd64/kubectl.exe`
+	
+To use the plugin, the Bluemix CLI must first be installed. You can find information to install the CLI here: https://console.bluemix.net/docs/cli/reference/bluemix_cli/index.html#getting-started
+
+To use the plugin itself, you must install it by running the following command: `bx plugin install dev -r Bluemix`


### PR DESCRIPTION
These are the doc changes that will coincide with the new release of the CLI `dev` plug-in.  The release is on 9/1/17, and so we would not want this to go into production until that day.  These have been reviewed by our OM @kfbishop and architect @amtrice (though they are not available in the Reviewers drop-down list).